### PR TITLE
Replace UNPKG w/ jsDelivr

### DIFF
--- a/other/breve.html
+++ b/other/breve.html
@@ -39,7 +39,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com">
 <link href="https://fonts.googleapis.com/css2?family=Karla:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;1,400&display=swap" rel="stylesheet">
 
-<script src="https://unpkg.com/@phosphor-icons/web"></script>
+<script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web"></script>
 
 <script>
 setTimeout(redirectTumblr, 3000);

--- a/pages/barlows.html
+++ b/pages/barlows.html
@@ -29,7 +29,7 @@
 </script>
 
 
-<!-- TOOLTIP: tippy.js scale --><link rel="stylesheet" href="https://unpkg.com/tippy.js@6/animations/scale-subtle.css">
+<!-- TOOLTIP: tippy.js scale --><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tippy.js@6/animations/scale-subtle.css">
 
 <!-- Google font -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -800,11 +800,11 @@ DO NOT TOUCH FROM HERE AND BEYOND
 <!-- jQuery -->
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
 <!-- TOOLTIP: tippy.js-->
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- ICONS: phosphor -->
-<script src="https://unpkg.com/phosphor-icons"></script>
+<script src="https://cdn.jsdelivr.net/npm/phosphor-icons"></script>
 
 <script>
 

--- a/pages/flake.html
+++ b/pages/flake.html
@@ -29,10 +29,10 @@
 <link rel="alternate" type="application/rss+xml" href="{RSS}">
 {block:Description}<meta name="description" content="{MetaDescription}" />{/block:Description}
  
-<link rel="stylesheet" href="https://unpkg.com/tippy.js@6/animations/scale-subtle.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tippy.js@6/animations/scale-subtle.css">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<script src="https://unpkg.com/phosphor-icons"></script>
+<script src="https://cdn.jsdelivr.net/npm/phosphor-icons"></script>
 
 <script>
     const storedTheme = localStorage.getItem("theme") || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
@@ -631,9 +631,9 @@ replace the URL of the icon with one of your own. -->
 <!-- right content end--> 
 
 <!-- jQuery --><script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-<!-- TOOLTIP: tippy.js --><script src="https://unpkg.com/@popperjs/core@2"></script>
-<!-- TOOLTIP: tippy.js--><script src="https://unpkg.com/tippy.js@6"></script>
-<!-- ICONS: phosphor --><script src="https://unpkg.com/phosphor-icons"></script>
+<!-- TOOLTIP: tippy.js --><script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
+<!-- TOOLTIP: tippy.js--><script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
+<!-- ICONS: phosphor --><script src="https://cdn.jsdelivr.net/npm/phosphor-icons"></script>
 
 <script>
 ////////////////// jquery dependant

--- a/pages/lune.html
+++ b/pages/lune.html
@@ -20,7 +20,7 @@
 <link rel="alternate" type="application/rss+xml" href="{RSS}">
 {block:Description}<meta name="description" content="{MetaDescription}" />{/block:Description}
 <link rel="stylesheet" href="//glenthemes.github.io/iconsax/style.css"> 
-<link rel="stylesheet" href="https://unpkg.com/tippy.js@6/animations/scale-subtle.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tippy.js@6/animations/scale-subtle.css">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
@@ -599,10 +599,10 @@ Here you can have a small description text. This is <a href="#">a link</a>.
 <!-- right content end--> 
 
 <!-- jQuery --><script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-<!-- TOOLTIP: tippy.js --><script src="https://unpkg.com/@popperjs/core@2"></script>
-<!-- TOOLTIP: tippy.js--><script src="https://unpkg.com/tippy.js@6"></script>
+<!-- TOOLTIP: tippy.js --><script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
+<!-- TOOLTIP: tippy.js--><script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- ICONS: iconsax --><script src="//glenthemes.github.io/iconsax/geticons.js"></script>
-<!-- ICONS: phosphor --><script src="https://unpkg.com/phosphor-icons"></script>
+<!-- ICONS: phosphor --><script src="https://cdn.jsdelivr.net/npm/phosphor-icons"></script>
 
 <script>
 ////////////////// jquery dependant

--- a/pages/malaga.html
+++ b/pages/malaga.html
@@ -29,7 +29,7 @@
     if (storedTheme) document.documentElement.setAttribute("data-theme", storedTheme); 
 </script>
 
-<!-- TOOLTIP: tippy.js scale --><link rel="stylesheet" href="https://unpkg.com/tippy.js@6/animations/scale-subtle.css">
+<!-- TOOLTIP: tippy.js scale --><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tippy.js@6/animations/scale-subtle.css">
 
 <!-- Google font -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -952,10 +952,10 @@ LIKES & DISLIKES - should be pretty straight forward. copy
 <!-- right content end--> 
 
 <!-- jQuery --><script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-<!-- TOOLTIP: tippy.js --><script src="https://unpkg.com/@popperjs/core@2"></script>
-<!-- TOOLTIP: tippy.js--><script src="https://unpkg.com/tippy.js@6"></script>
-<!-- ICONS: phosphor --><script src="https://unpkg.com/phosphor-icons"></script>
-<!-- ICONS: Lucide --><script src="https://unpkg.com/lucide@latest"></script>
+<!-- TOOLTIP: tippy.js --><script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
+<!-- TOOLTIP: tippy.js--><script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
+<!-- ICONS: phosphor --><script src="https://cdn.jsdelivr.net/npm/phosphor-icons"></script>
+<!-- ICONS: Lucide --><script src="https://cdn.jsdelivr.net/npm/lucide@latest"></script>
 
 <script>
 // icons

--- a/themes/amber.html
+++ b/themes/amber.html
@@ -153,7 +153,7 @@
 <!-- PHOTOSETS: pxu -->
 <link href="https://static.tumblr.com/qudkd6d/OcDnl99gb/style.css" rel="stylesheet" type="text/css"/>
 <!-- TOOLTIP: tippy.js scale -->
-<link rel="stylesheet" href="https://unpkg.com/tippy.js@6/animations/scale-subtle.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tippy.js@6/animations/scale-subtle.css">
 <!-- Google font -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -2282,9 +2282,9 @@ aside#sidebar #title {
 <script src="//npf-images-v3.github.io/script.js"></script>
 <!-- PHOTOSETS: pxu -->
 <script src="https://static.tumblr.com/yxfeliq/hHwojmt8m/bctphotoset.min.js"></script>
-<!-- TOOLTIP: tippy.js --><script src="https://unpkg.com/@popperjs/core@2"></script>
-<!-- TOOLTIP: tippy.js--><script src="https://unpkg.com/tippy.js@6"></script>
-<!-- ICONS: Lucide --><script src="https://unpkg.com/lucide@latest"></script>
+<!-- TOOLTIP: tippy.js --><script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
+<!-- TOOLTIP: tippy.js--><script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
+<!-- ICONS: Lucide --><script src="https://cdn.jsdelivr.net/npm/lucide@latest"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <!-- AUDIO: legacy audio annasthms -->

--- a/themes/autumn.html
+++ b/themes/autumn.html
@@ -1986,8 +1986,8 @@ button.scroll-to-top.visible, button.scroll-to-top-mobile.visible {
 <!-- PHOTOSET: legacy -->
 <script src="https://static.tumblr.com/diajl5m/y39s6mwvr/legacy-photoset.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/annasthms/customaudio@latest/customaudio.min.js"></script>

--- a/themes/blithe.html
+++ b/themes/blithe.html
@@ -1978,11 +1978,11 @@ span.activity-icon {
 <svg height="0" width="0" class="hide-it"><defs><clipPath id="blob" clipPathUnits="objectBoundingBox"><path d="M0.5,0.053c0.266,-0.074 0.242,0.198 0.44,0.447c0.161,0.204 -0.209,0.435 -0.44,0.455c-0.275,0.023 -0.516,-0.183 -0.471,-0.455c0.037,-0.217 0.235,-0.382 0.471,-0.447Z"></path></clipPath></defs></svg>
 
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
 <!-- TOOLTIP: tippy.js-->
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- ICONS: phosphor -->
-<script src="https://unpkg.com/@phosphor-icons/web"></script>
+<script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <!-- AUDIO: legacy audio annasthms -->

--- a/themes/bloomy.html
+++ b/themes/bloomy.html
@@ -128,7 +128,7 @@
 <!-- PHOTOSETS: pxu -->
 <link href="https://static.tumblr.com/qudkd6d/OcDnl99gb/style.css" rel="stylesheet" type="text/css"/>
 <!-- TOOLTIP: tippy.js scale -->
-<link rel="stylesheet" href="https://unpkg.com/tippy.js@6/animations/scale-subtle.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tippy.js@6/animations/scale-subtle.css">
 <!-- Google font -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -1864,11 +1864,11 @@ span.toggle::after {
 <!-- PHOTOSETS: pxu -->
 <script src="https://static.tumblr.com/yxfeliq/hHwojmt8m/bctphotoset.min.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
 <!-- TOOLTIP: tippy.js-->
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- ICONS: phosphor -->
-<script src="https://unpkg.com/@phosphor-icons/web"></script>
+<script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <!-- AUDIO: legacy audio annasthms -->

--- a/themes/brasch.html
+++ b/themes/brasch.html
@@ -207,7 +207,7 @@
 <!-- PHOTOSETS: pxu -->
 <link href="https://static.tumblr.com/qudkd6d/OcDnl99gb/style.css" rel="stylesheet" type="text/css"/>
 <!-- TOOLTIP: tippy.js scale -->
-<link rel="stylesheet" href="https://unpkg.com/tippy.js@6/animations/scale-subtle.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tippy.js@6/animations/scale-subtle.css">
 <!-- Google font -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -2551,11 +2551,11 @@ remember to fill out URL (the #) and blog name.
 <!-- PHOTOSETS: pxu -->
 <script src="https://static.tumblr.com/yxfeliq/hHwojmt8m/bctphotoset.min.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
 <!-- TOOLTIP: tippy.js-->
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- ICONS: phosphor -->
-<script src="https://unpkg.com/@phosphor-icons/web"></script>
+<script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <!-- AUDIO: legacy audio annasthms -->

--- a/themes/broek.html
+++ b/themes/broek.html
@@ -125,7 +125,7 @@
 <!-- AUDIO: npf audio glenthemes -->
 <link href="//tmblr-npf-audio.gitlab.io/s/base.css" rel="stylesheet">
 <!-- TOOLTIP: tippy.js scale -->
-<link rel="stylesheet" href="https://unpkg.com/tippy.js@6/animations/scale-subtle.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tippy.js@6/animations/scale-subtle.css">
 <!-- Google font -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -2008,11 +2008,11 @@ span.act-icon {
 <!-- PHOTOSETS: pxu -->
 <script src="https://static.tumblr.com/yxfeliq/hHwojmt8m/bctphotoset.min.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
 <!-- TOOLTIP: tippy.js-->
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- ICONS: phosphor -->
-<script src="https://unpkg.com/@phosphor-icons/web"></script>
+<script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <!-- AUDIO: legacy audio annasthms -->

--- a/themes/bruges.html
+++ b/themes/bruges.html
@@ -1915,8 +1915,8 @@ button.scroll-to-top.visible {
 <!-- PHOTOSET: legacy -->
 <script src="https://static.tumblr.com/diajl5m/y39s6mwvr/legacy-photoset.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <!-- AUDIO: legacy audio annasthms -->

--- a/themes/dusty.html
+++ b/themes/dusty.html
@@ -2590,9 +2590,9 @@ iframe#submit_form {
 
 
 <script src="https://static.tumblr.com/diajl5m/y39s6mwvr/legacy-photoset.js"></script>
-<script src="https://unpkg.com/@popperjs/core@2"></script>
-<script src="https://unpkg.com/tippy.js@6"></script>
-<script src="https://unpkg.com/lucide@latest"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/lucide@latest"></script>
 <script src="https://static.tumblr.com/diajl5m/mobsquso5/unify_audio.js"></script>
 
 <script>

--- a/themes/everlong.html
+++ b/themes/everlong.html
@@ -116,7 +116,7 @@
 <!-- PHOTOSETS: pxu -->
 <link href="https://static.tumblr.com/qudkd6d/OcDnl99gb/style.css" rel="stylesheet" type="text/css"/>
 <!-- TOOLTIP: tippy.js scale -->
-<link rel="stylesheet" href="https://unpkg.com/tippy.js@6/animations/scale-subtle.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tippy.js@6/animations/scale-subtle.css">
 <!-- Google font -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -1759,11 +1759,11 @@ span.toggle::after {
 <!-- PHOTOSETS: pxu -->
 <script src="https://static.tumblr.com/yxfeliq/hHwojmt8m/bctphotoset.min.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
 <!-- TOOLTIP: tippy.js-->
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- ICONS: phosphor -->
-<script src="https://unpkg.com/@phosphor-icons/web"></script>
+<script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <!-- AUDIO: legacy audio annasthms -->

--- a/themes/isla.html
+++ b/themes/isla.html
@@ -1955,12 +1955,12 @@ button.close {
     <i class="ph ph-caret-up"></i>
 </button>
 
-<script src="https://unpkg.com/@phosphor-icons/web"></script>
+<script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web"></script>
 <!-- PHOTOSET: legacy -->
 <script src="https://static.tumblr.com/diajl5m/y39s6mwvr/legacy-photoset.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/annasthms/customaudio@latest/customaudio.min.js"></script>

--- a/themes/jude.html
+++ b/themes/jude.html
@@ -3400,10 +3400,10 @@ transform: rotate(0) translateY(100%);
 <!-- AUDIO -->
 <script src="https://cdn.jsdelivr.net/gh/flipsewtf/custom-audio/audio-npf-legacy.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- ICON: lucide -->
-<script src="https://unpkg.com/lucide@latest"></script>
+<script src="https://cdn.jsdelivr.net/npm/lucide@latest"></script>
 
 <script>
 lucide.createIcons();

--- a/themes/kana.html
+++ b/themes/kana.html
@@ -130,7 +130,7 @@
 <!-- AUDIO: npf audio glenthemes -->
 <link href="//tmblr-npf-audio.gitlab.io/s/base.css" rel="stylesheet">
 <!-- TOOLTIP: tippy.js scale -->
-<link rel="stylesheet" href="https://unpkg.com/tippy.js@6/animations/scale-subtle.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tippy.js@6/animations/scale-subtle.css">
 <!-- Google font -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -1966,9 +1966,9 @@ button.tab-toggle svg {
 <!-- PHOTOSETS: pxu -->
 <script src="https://static.tumblr.com/yxfeliq/hHwojmt8m/bctphotoset.min.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
 <!-- TOOLTIP: tippy.js-->
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <!-- AUDIO: legacy audio anasthms  -->

--- a/themes/leaf.html
+++ b/themes/leaf.html
@@ -2663,9 +2663,9 @@ iframe#submit_form {
 
 
 <script src="https://static.tumblr.com/diajl5m/y39s6mwvr/legacy-photoset.js"></script>
-<script src="https://unpkg.com/@popperjs/core@2"></script>
-<script src="https://unpkg.com/tippy.js@6"></script>
-<script src="https://unpkg.com/lucide@latest"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/lucide@latest"></script>
 <script src="https://static.tumblr.com/diajl5m/mobsquso5/unify_audio.js"></script>
 
 <script>

--- a/themes/mauve.html
+++ b/themes/mauve.html
@@ -123,7 +123,7 @@
 <!-- PHOTOSETS: pxu -->
 <link href="https://static.tumblr.com/qudkd6d/OcDnl99gb/style.css" rel="stylesheet" type="text/css"/>
 <!-- TOOLTIP: tippy.js scale -->
-<link rel="stylesheet" href="https://unpkg.com/tippy.js@6/animations/scale-subtle.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tippy.js@6/animations/scale-subtle.css">
 <!-- Google font -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -2042,11 +2042,11 @@ button.sb-close {
 <!-- PHOTOSETS: pxu -->
 <script src="https://static.tumblr.com/yxfeliq/hHwojmt8m/bctphotoset.min.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
 <!-- TOOLTIP: tippy.js-->
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- ICONS: Lucide -->
-<script src="https://unpkg.com/lucide@latest"></script>
+<script src="https://cdn.jsdelivr.net/npm/lucide@latest"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <!-- AUDIO: legacy audio annasthms -->

--- a/themes/palm.html
+++ b/themes/palm.html
@@ -2230,12 +2230,12 @@ nav.mobile-menu::after {
 <svg height="0" width="0" style="position:absolute; width:0px; height:0px;"><defs><clipPath id="blob" clipPathUnits="objectBoundingBox"><path d="M0.5,0.053c0.266,-0.074 0.242,0.198 0.44,0.447c0.161,0.204 -0.209,0.435 -0.44,0.455c-0.275,0.023 -0.516,-0.183 -0.471,-0.455c0.037,-0.217 0.235,-0.382 0.471,-0.447Z"></path></clipPath></defs></svg>
 
 <!-- IXONS: phosphor -->
-<script src="https://unpkg.com/@phosphor-icons/web"></script>
+<script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web"></script>
 <!-- PHOTOSET: legacy -->
 <script src="https://static.tumblr.com/diajl5m/y39s6mwvr/legacy-photoset.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <!-- AUDIO: legacy audio annasthms -->

--- a/themes/saturday.html
+++ b/themes/saturday.html
@@ -1913,8 +1913,8 @@ button.scroll-to-top.visible:hover {
 <!-- PHOTOSET: legacy -->
 <script src="https://static.tumblr.com/diajl5m/y39s6mwvr/legacy-photoset.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <!-- AUDIO: legacy audio annasthms -->

--- a/themes/sevens.html
+++ b/themes/sevens.html
@@ -2012,11 +2012,11 @@ span.activity-icon {
 
 
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
 <!-- TOOLTIP: tippy.js-->
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- ICONS: phosphor -->
-<script src="https://unpkg.com/@phosphor-icons/web"></script>
+<script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <!-- AUDIO: legacy audio annasthms -->

--- a/themes/sprung.html
+++ b/themes/sprung.html
@@ -1936,8 +1936,8 @@ button.scroll-to-top.visible {
 <!-- PHOTOSET: legacy -->
 <script src="https://static.tumblr.com/diajl5m/y39s6mwvr/legacy-photoset.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 

--- a/themes/suburban.html
+++ b/themes/suburban.html
@@ -1913,8 +1913,8 @@ button.scroll-to-top.visible {
 <!-- PHOTOSET: legacy -->
 <script src="https://static.tumblr.com/diajl5m/y39s6mwvr/legacy-photoset.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <!-- AUDIO: legacy audio annasthms -->

--- a/themes/ville.html
+++ b/themes/ville.html
@@ -1929,8 +1929,8 @@ button.scroll-to-top.visible {
 <!-- PHOTOSET: legacy -->
 <script src="https://static.tumblr.com/diajl5m/y39s6mwvr/legacy-photoset.js"></script>
 <!-- TOOLTIP: tippy.js -->
-<script src="https://unpkg.com/@popperjs/core@2"></script>
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/tippy.js@6"></script>
 <!-- AUDIO: npf audio glenthemes -->
 <script src="//tmblr-npf-audio.gitlab.io/s/init.js"></script>
 <!-- AUDIO: legacy audio annasthms -->


### PR DESCRIPTION
UNPKG has not been actively maintained and ~~has been down since `Mar 15, 2025`~~ was down from Mar 15, 2025, 2:00 AM and down for 18 hours (https://github.com/unpkg/unpkg/issues/412). Migrating to jsDelivr means a more stable and reliant service.

The PR replaces UNPKG usage with jsDelivr.